### PR TITLE
jaeger-pam

### DIFF
--- a/pam/closedsource/docker-compose.yml
+++ b/pam/closedsource/docker-compose.yml
@@ -233,7 +233,6 @@ services:
          ES_SERVER_URLS: http://elasticsearch:9200
       ports:
          - 16685:16685
-         - 16685:16685
          - 16686:16686
       restart: on-failure
 


### PR DESCRIPTION
PAM jaeger container for closed source has duplicate port mapping so removed.