### PR TITLE
fixed environment name for robot containers

### DIFF
--- a/copregion/closedsource/docker-compose.yml
+++ b/copregion/closedsource/docker-compose.yml
@@ -363,7 +363,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -374,6 +373,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /home/administrator/celerybeat:/opt/robot/celerybeat
@@ -392,7 +392,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -403,6 +402,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /etc/cloudcix/robot:/mnt/images

--- a/copregion/opensource/docker-compose.yml
+++ b/copregion/opensource/docker-compose.yml
@@ -349,7 +349,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -360,6 +359,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /home/administrator/celerybeat:/opt/robot/celerybeat
@@ -378,7 +378,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -389,6 +388,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /etc/cloudcix/robot:/mnt/images

--- a/pamcopregion/closedsource/docker-compose.yml
+++ b/pamcopregion/closedsource/docker-compose.yml
@@ -724,7 +724,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -735,6 +734,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /home/administrator/celerybeat:/opt/robot/celerybeat
@@ -753,7 +753,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -764,6 +763,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /etc/cloudcix/robot:/mnt/images

--- a/pamcopregion/opensource/docker-compose.yml
+++ b/pamcopregion/opensource/docker-compose.yml
@@ -601,7 +601,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -612,6 +611,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /home/administrator/celerybeat:/opt/robot/celerybeat
@@ -630,7 +630,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -641,6 +640,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /etc/cloudcix/robot:/mnt/images

--- a/region/closedsource/docker-compose.yml
+++ b/region/closedsource/docker-compose.yml
@@ -23,7 +23,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -34,6 +33,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /home/administrator/celerybeat:/opt/robot/celerybeat
@@ -52,7 +52,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -63,6 +62,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /etc/cloudcix/robot:/mnt/images

--- a/region/opensource/docker-compose.yml
+++ b/region/opensource/docker-compose.yml
@@ -23,7 +23,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -34,6 +33,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /home/administrator/celerybeat:/opt/robot/celerybeat
@@ -52,7 +52,6 @@ services:
          - EMAIL_PASSWORD=${REGION_EMAIL_PASSWORD}
          - EMAIL_PORT=${REGION_EMAIL_PORT}
          - EMAIL_USER=${REGION_EMAIL_USER}
-         - MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - NETWORK_PASSWORD=${NETWORK_PASSWORD}
          - PAM_NAME=${REGION_PAM_NAME}
          - PAM_ORGANIZATION_URL=${REGION_PAM_ORGANIZATION_URL}
@@ -63,6 +62,7 @@ services:
          - ROBOT_API_KEY=${ROBOT_API_KEY}
          - ROBOT_API_PASSWORD=${ROBOT_API_PASSWORD}
          - ROBOT_API_USERNAME=${ROBOT_API_USERNAME}
+         - ROUTER_MGMT_IP=${ROUTER_MANAGEMENT_IP}
          - SEND_TO_FAIL=${SEND_TO_FAIL}
       volumes:
          - /etc/cloudcix/robot:/mnt/images


### PR DESCRIPTION
Robot expects `- ROUTER_MGMT_IP` to set as `MGMT_IP` in settings file