### PR TITLE
Increase heap size allocated to elasticsearch

### DIFF
--- a/pam/closedsource/docker-compose.yml
+++ b/pam/closedsource/docker-compose.yml
@@ -260,7 +260,7 @@ services:
          - cluster.name=docker-cluster
          - bootstrap.memory_lock=true
          - discovery.type=single-node
-         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+         - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
          - MAX_MAP_COUNT=262144
       ulimits:
          memlock:

--- a/pamcop/closedsource/docker-compose.yml
+++ b/pamcop/closedsource/docker-compose.yml
@@ -260,7 +260,7 @@ services:
          - cluster.name=docker-cluster
          - bootstrap.memory_lock=true
          - discovery.type=single-node
-         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+         - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
          - MAX_MAP_COUNT=262144
       ulimits:
          memlock:

--- a/pamcopregion/closedsource/docker-compose.yml
+++ b/pamcopregion/closedsource/docker-compose.yml
@@ -260,7 +260,7 @@ services:
          - cluster.name=docker-cluster
          - bootstrap.memory_lock=true
          - discovery.type=single-node
-         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+         - "ES_JAVA_OPTS=-Xms4g -Xmx4g"
          - MAX_MAP_COUNT=262144
       ulimits:
          memlock:


### PR DESCRIPTION
ES is a memory intensive program and will crash frequently if it reaches the set memory limit.