### PR TITLE
Mount static content onto /app_framework/static

### DIFF
--- a/cop/closedsource/docker-compose.yml
+++ b/cop/closedsource/docker-compose.yml
@@ -331,7 +331,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp

--- a/cop/opensource/docker-compose.yml
+++ b/cop/opensource/docker-compose.yml
@@ -318,7 +318,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp

--- a/copregion/closedsource/docker-compose.yml
+++ b/copregion/closedsource/docker-compose.yml
@@ -341,7 +341,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp

--- a/copregion/opensource/docker-compose.yml
+++ b/copregion/opensource/docker-compose.yml
@@ -327,7 +327,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp

--- a/pamcop/closedsource/docker-compose.yml
+++ b/pamcop/closedsource/docker-compose.yml
@@ -702,7 +702,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp

--- a/pamcop/opensource/docker-compose.yml
+++ b/pamcop/opensource/docker-compose.yml
@@ -579,7 +579,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp

--- a/pamcopregion/closedsource/docker-compose.yml
+++ b/pamcopregion/closedsource/docker-compose.yml
@@ -702,7 +702,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp

--- a/pamcopregion/opensource/docker-compose.yml
+++ b/pamcopregion/opensource/docker-compose.yml
@@ -579,7 +579,7 @@ services:
       volumes:
          - ./templates/cop:/etc/nginx/templates
          - /etc/nginx/certs:/etc/nginx/certs
-         - cop_static_content:/static
+         - cop_static_content:/app_framework/static
       depends_on:
          - membership
          - otp


### PR DESCRIPTION
The nginx config searches for static content for the UI at /app_framework/static. We may as well define that it's for the app_framework in case we need to serve other static content in the future.