### PR TITLE
Add network aliases to API

### DIFF
--- a/cop/closedsource/docker-compose.yml
+++ b/cop/closedsource/docker-compose.yml
@@ -83,6 +83,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -117,6 +120,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -159,6 +165,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -207,6 +216,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -238,6 +250,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static

--- a/cop/opensource/docker-compose.yml
+++ b/cop/opensource/docker-compose.yml
@@ -82,6 +82,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -115,6 +118,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -156,6 +162,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -202,6 +211,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -232,6 +244,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static

--- a/copregion/closedsource/docker-compose.yml
+++ b/copregion/closedsource/docker-compose.yml
@@ -93,6 +93,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -127,6 +130,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -169,6 +175,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -217,6 +226,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -248,6 +260,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static

--- a/copregion/opensource/docker-compose.yml
+++ b/copregion/opensource/docker-compose.yml
@@ -92,6 +92,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -125,6 +128,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -166,6 +172,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -212,6 +221,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -242,6 +254,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static

--- a/pamcop/closedsource/docker-compose.yml
+++ b/pamcop/closedsource/docker-compose.yml
@@ -454,6 +454,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -488,6 +491,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -530,6 +536,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -578,6 +587,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -609,6 +621,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static

--- a/pamcop/opensource/docker-compose.yml
+++ b/pamcop/opensource/docker-compose.yml
@@ -344,6 +344,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -377,6 +380,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -418,6 +424,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -464,6 +473,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -494,6 +506,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static

--- a/pamcopregion/closedsource/docker-compose.yml
+++ b/pamcopregion/closedsource/docker-compose.yml
@@ -454,6 +454,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -488,6 +491,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -530,6 +536,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -578,6 +587,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -609,6 +621,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static

--- a/pamcopregion/opensource/docker-compose.yml
+++ b/pamcopregion/opensource/docker-compose.yml
@@ -344,6 +344,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:1"
+            aliases:
+              - "membership"
+              - "membership.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}:/application_framework/private-key.rsa
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
@@ -377,6 +380,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:2"
+            aliases:
+              - "otp"
+              - "otp.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -418,6 +424,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:3"
+            aliases:
+              - "iaas"
+              - "iaas.${PORTAL_NAME}.${ORGANIZATION_URL}"
       environment:
          - CLOUDCIX_API_KEY=${CLOUDCIX_API_KEY}
          - CLOUDCIX_API_PASSWORD=${CLOUDCIX_API_PASSWORD}
@@ -464,6 +473,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}4004:4"
+            aliases:
+              - "appmanager"
+              - "appmanager.${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/application_framework/public-key.rsa
       restart: on-failure
@@ -494,6 +506,9 @@ services:
       networks:
          mgmt:
             ipv6_address: "${DOCKER_MGMT_IP6}5002:4"
+            aliases:
+              - "cop"
+              - "${PORTAL_NAME}.${ORGANIZATION_URL}"
       volumes:
          - /home/administrator/.ssh/id_rsa_${pod_id}.pub:/app_framework/system_conf/public-key.rsa
          - cop_static_content:/static


### PR DESCRIPTION
Allow API containers to reach each other directly using docker's internal DNS instead of making them request through the nginx container.