### PR TITLE
Keep existing ldap config

### DIFF
--- a/cop/closedsource/docker-compose.yml
+++ b/cop/closedsource/docker-compose.yml
@@ -276,6 +276,7 @@ services:
       networks:
          mgmt:
       environment:
+         - KEEP_EXISTING_CONFIG=true
          - LDAP_ADMIN_PASSWORD=${MEMBERSHIPLDAP_PASSWORD}
          - LDAP_DOMAIN=${ORGANIZATION_URL}
          - LDAP_ORGANISATION=${ORGANIZATION_URL}

--- a/cop/opensource/docker-compose.yml
+++ b/cop/opensource/docker-compose.yml
@@ -276,6 +276,7 @@ services:
       networks:
          mgmt:
       environment:
+         - KEEP_EXISTING_CONFIG=true
          - LDAP_ADMIN_PASSWORD=${MEMBERSHIPLDAP_PASSWORD}
          - LDAP_DOMAIN=${ORGANIZATION_URL}
          - LDAP_ORGANISATION=${ORGANIZATION_URL}

--- a/copregion/closedsource/docker-compose.yml
+++ b/copregion/closedsource/docker-compose.yml
@@ -287,6 +287,7 @@ services:
       networks:
          mgmt:
       environment:
+         - KEEP_EXISTING_CONFIG=true
          - LDAP_ADMIN_PASSWORD=${MEMBERSHIPLDAP_PASSWORD}
          - LDAP_DOMAIN=${ORGANIZATION_URL}
          - LDAP_ORGANISATION=${ORGANIZATION_URL}

--- a/copregion/opensource/docker-compose.yml
+++ b/copregion/opensource/docker-compose.yml
@@ -287,6 +287,7 @@ services:
       networks:
          mgmt:
       environment:
+         - KEEP_EXISTING_CONFIG=true
          - LDAP_ADMIN_PASSWORD=${MEMBERSHIPLDAP_PASSWORD}
          - LDAP_DOMAIN=${ORGANIZATION_URL}
          - LDAP_ORGANISATION=${ORGANIZATION_URL}


### PR DESCRIPTION
Ldap container reverted admin password on reboot. According to this thread (https://github.com/osixia/docker-openldap/issues/559) setting the environment variable `KEEP_EXISTING_CONFIG=true` prevents the server overwriting the config.