### PR TITLE
version_obsolete

### DIFF
--- a/cop/docker-compose.yml
+++ b/cop/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   mgmt:
     driver: bridge

--- a/copregion/docker-compose.yml
+++ b/copregion/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   mgmt:
     driver: bridge

--- a/region/docker-compose.yml
+++ b/region/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   mgmt:
     driver: bridge


### PR DESCRIPTION
Resolve below warning message:

WARN[0000] docker-compose.yml: `version` is obsolete