### PR TITLE
store large reports and serve via nginx2

### DIFF
--- a/cop/nginx2.conf.template
+++ b/cop/nginx2.conf.template
@@ -57,6 +57,7 @@ server {
     client_max_body_size 0;
     # To disable buffering
     proxy_buffering off;
+    proxy_request_buffering off;
 
     location /media/ {
         alias /application_framework/media/;
@@ -83,6 +84,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
 
         proxy_connect_timeout 300;
+        proxy_read_timeout 300s;
         # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
         proxy_http_version 1.1;
         proxy_set_header Connection "";

--- a/copregion/nginx2.conf.template
+++ b/copregion/nginx2.conf.template
@@ -57,6 +57,7 @@ server {
     client_max_body_size 0;
     # To disable buffering
     proxy_buffering off;
+    proxy_request_buffering off;
 
     location /media/ {
         alias /application_framework/media/;
@@ -83,6 +84,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
 
         proxy_connect_timeout 300;
+        proxy_read_timeout 300s;
         # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
         proxy_http_version 1.1;
         proxy_set_header Connection "";


### PR DESCRIPTION
Turn off request_buffering for serving large reports via proxy from reporting